### PR TITLE
Prevent a random NameError

### DIFF
--- a/lib/rackconnect.rb
+++ b/lib/rackconnect.rb
@@ -8,6 +8,7 @@ end
 
 # Load after token/tenant_id setup
 require "rackconnect/version"
+require 'active_support'
 require "active_support/inflector"
 require "active_support/core_ext"
 require "rest-client"


### PR DESCRIPTION
The error I'm trying to fix is this one, when running the tests:

```
NameError:
  uninitialized constant ActiveSupport::Autoload
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/number_helper.rb:5:in `<module:NumberHelper>'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/number_helper.rb:4:in `<module:ActiveSupport>'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/number_helper.rb:3:in `<top (required)>'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/core_ext/numeric/conversions.rb:4:in `require'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/core_ext/numeric/conversions.rb:4:in `<top (required)>'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/core_ext/numeric.rb:5:in `require'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/core_ext/numeric.rb:5:in `<top (required)>'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/core_ext.rb:4:in `require'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/core_ext.rb:4:in `block in <top (required)>'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/core_ext.rb:3:in `each'
# /home/edward/.rvm/gems/ruby-2.6.8@rackconnect/gems/activesupport-6.1.4.4/lib/active_support/core_ext.rb:3:in `<top (required)>'
# ./lib/rackconnect.rb:12:in `require'
# ./lib/rackconnect.rb:12:in `<top (required)>'
# ./spec/spec_helper.rb:4:in `require'
# ./spec/spec_helper.rb:4:in `<top (required)>'
# ./spec/rackconnect/models/server_group_node_spec.rb:1:in `require'
# ./spec/rackconnect/models/server_group_node_spec.rb:1:in `<top (required)>'
```

However, I believe samjsharpe's fix should do that. Original description from https://github.com/rackerlabs/rackconnect/pull/1:

----------

Rackconnect cherrypicks core_ext from active_support and on my machine at least
suffers from the problems described in rails/rails#14664

By adding this line, I can avoid this error:

```
$ bundle exec rake mock:spec
/Library/Ruby/Gems/2.0.0/gems/activesupport-4.2.4/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
```

And instead get this:

```
$ bundle exec rake mock:spec
Finished in 0.00024 seconds (files took 0.70872 seconds to load)
0 examples, 0 failures
```

I discovered this via Joe Quinn and was running this sample script which exhibited
the error (on the rackconnect-0.0.1 gem, but master is broken for me too). The
script should die with RestClient::Unauthorized but actually dies with a NameError
when it tries to call Rackconnect::Auth:

```
$ ruby test.rb
test.rb:5:in `<main>': uninitialized constant Rackconnect::Auth (NameError)
```

```

require './lib/rackconnect'

rc = Rackconnect::Auth.new({
    api_key: "foo",
    username: "bar"
})
```

For completeness, I was running this on OS X 10.10 and my bundle looks like this:

```
$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/..
Resolving dependencies...
Installing rake 10.4.2
Using i18n 0.7.0
Using json 1.8.3
Installing minitest 5.8.1
Using thread_safe 0.3.5
Using tzinfo 1.2.2
Using activesupport 4.2.4
Installing builder 3.2.2
Installing activemodel 4.2.4
Using bundler 1.10.6
Installing coderay 1.1.0
Installing daemons 1.2.3
Installing diff-lcs 1.2.5
Using unf_ext 0.0.7.1
Using unf 0.1.4
Using domain_name 0.5.24
Installing eventmachine 1.0.8 with native extensions
Using http-cookie 1.0.2
Installing method_source 0.8.2
Using mime-types 2.6.2
Using netrc 0.10.3
Installing slop 3.6.0
Installing pry 0.10.2
Installing rack 1.6.4
Installing rack-protection 1.5.3
Using rest-client 1.8.0
Using rackconnect 0.0.1 from source at .
Installing rspec-support 3.3.0
Installing rspec-core 3.3.2
Installing rspec-expectations 3.3.1
Installing rspec-mocks 3.3.2
Installing rspec 3.3.0
Installing tilt 2.0.1
Installing sinatra 1.4.6
Installing thin 1.6.4 with native extensions
Bundle complete! 7 Gemfile dependencies, 35 gems now installed.
Use `bundle show [gemname]` to see where a bundled gem is installed.
```